### PR TITLE
Fixing updating gdal using ubuntugis-unstable in init.sh

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -13,6 +13,7 @@ TOP=$(cd $(dirname $0) && pwd)
 set -o errexit
 set -o xtrace
 
+sudo apt-get update
 sudo apt-get install -y --force-yes python-software-properties
 sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable
 


### PR DESCRIPTION
Adding a apt-get update before installing python-software-properties
