### PR TITLE
Setting up config skip

### DIFF
--- a/radiometric_normalization/normalize.py
+++ b/radiometric_normalization/normalize.py
@@ -43,13 +43,12 @@ def generate_transforms(candidate_path, reference_paths, config=None):
 
     if config['pif_method'] != 'skip':
         pif_weight, reference_gimg, candidate_gimg = pif.generate(
-            candidate_path, reference_path=reference_image,
+            candidate_path, reference_image,
             method=config['pif_method'])
     else:
         # Assumes that the reference_paths is an image with the pif strength
-        # weightings as the alpha band (reference_paths is a single file name
-        # NOT a list of file names)
-        reference_gimg = gimage.load(reference_paths)
+        # weightings as the alpha band
+        reference_gimg = gimage.load(reference_image)
         candidate_gimg = gimage.load(candidate_path)
         pif_weight = reference_gimg.alpha
 
@@ -60,7 +59,9 @@ def generate_transforms(candidate_path, reference_paths, config=None):
     else:
         # Nothing really makes sense here, so just output an identity
         # transformation and ignore all inputs
-        transformations = transformation.LinearTransformation(1.0, 0.0)
+        no_bands = len(reference_gimg.bands)
+        transformations = [transformation.LinearTransformation(1.0, 0.0) for
+                           band_count in xrange(no_bands)]
 
     return transformations
 

--- a/radiometric_normalization/normalize.py
+++ b/radiometric_normalization/normalize.py
@@ -33,7 +33,7 @@ def generate_transforms(candidate_path, reference_paths, config=None):
 
     if config['time_stack_method'] != 'skip':
         reference_image = time_stack.generate(
-            reference_paths,
+            reference_paths, 'time_stack.tif',
             method=config['time_stack_method'])
     else:
         # Assumes that the reference_paths is a pre-made time stack or
@@ -43,7 +43,7 @@ def generate_transforms(candidate_path, reference_paths, config=None):
 
     if config['pif_method'] != 'skip':
         pif_weight, reference_gimg, candidate_gimg = pif.generate(
-            candidate_path, reference_image,
+            candidate_path, reference_path=reference_image,
             method=config['pif_method'])
     else:
         # Assumes that the reference_paths is an image with the pif strength

--- a/radiometric_normalization/normalize.py
+++ b/radiometric_normalization/normalize.py
@@ -23,6 +23,14 @@ def generate_transforms(candidate_path, reference_paths, config=None):
                   'pif_method': 'identity',
                   'transformation_method': 'linear_relationship'}
 
+    # Ensure all entries are there for partial configs
+    if 'time_stack_method' not in config:
+        config['time_stack_method'] = 'identity'
+    if 'pif_method' not in config:
+        config['pif_method'] = 'identity'
+    if 'transformation_method' not in config:
+        config['transformation_method'] = 'linear_relationship'
+
     reference_image = time_stack.generate(
         reference_paths,
         method=config['time_stack_method'])

--- a/radiometric_normalization/normalize.py
+++ b/radiometric_normalization/normalize.py
@@ -37,9 +37,12 @@ def generate_transformations(candidate_path, reference_paths, config=None):
             method=config['time_stack_method'])
     else:
         # Assumes that the reference_paths is a pre-made time stack or
-        # another compatible image
-        # i.e. it is a single file name NOT a list of file names
-        reference_image = reference_paths
+        # another compatible image (it needs to be a list of length one).
+        if len(reference_paths) == 1:
+            reference_image = reference_paths[0]
+        else:
+            raise NotImplementedError("If time stack generation is skipped, "
+                                      "only one reference image is expected.")
 
     if config['pif_method'] != 'skip':
         pif_weight, reference_gimg, candidate_gimg = pif.generate(

--- a/radiometric_normalization/normalize.py
+++ b/radiometric_normalization/normalize.py
@@ -17,7 +17,8 @@ from radiometric_normalization import \
     time_stack, pif, transformation, gimage
 
 
-def generate_transformations(candidate_path, reference_paths, config=None):
+def generate_transformations(candidate_path, reference_paths,
+                             config=None, pif_path=None):
     if config is None:
         config = {'time_stack_method': 'identity',
                   'pif_method': 'identity',
@@ -49,11 +50,19 @@ def generate_transformations(candidate_path, reference_paths, config=None):
             candidate_path, reference_path=reference_image,
             method=config['pif_method'])
     else:
-        # Assumes that the reference_paths is an image with the pif strength
-        # weightings as the alpha band
-        reference_gimg = gimage.load(reference_image)
-        candidate_gimg = gimage.load(candidate_path)
-        pif_weight = reference_gimg.alpha
+        # Assumes that the PIF image is a geotiff with one band that repesents
+        # the PIF weight.
+        if pif_path is not None:
+            reference_gimg = gimage.load(reference_image)
+            candidate_gimg = gimage.load(candidate_path)
+            pif_gimg = gimage.load(pif_path)
+            if len(pif_gimg.bands) == 1:
+                pif_weight = pif_gimg.band[0]
+            else:
+                raise NotImplementedError("The PIF weight image is not in an "
+                                          "expected format")
+        else:
+            raise NotImplementedError("No PIF weight image specified.")
 
     if config['transformation_method'] != 'skip':
         transformations = transformation.generate(

--- a/radiometric_normalization/normalize.py
+++ b/radiometric_normalization/normalize.py
@@ -17,7 +17,7 @@ from radiometric_normalization import \
     time_stack, pif, transformation, gimage
 
 
-def generate_transforms(candidate_path, reference_paths, config=None):
+def generate_transformations(candidate_path, reference_paths, config=None):
     if config is None:
         config = {'time_stack_method': 'identity',
                   'pif_method': 'identity',
@@ -66,7 +66,7 @@ def generate_transforms(candidate_path, reference_paths, config=None):
     return transformations
 
 
-def apply_transforms(input_path, transformations, output_path):
+def apply_transformations(input_path, transformations, output_path):
     gimg = gimage.load(input_path)
     out_gimg = transformation.apply(gimg, transformations)
     gimage.save(out_gimg, output_path)

--- a/radiometric_normalization/pif.py
+++ b/radiometric_normalization/pif.py
@@ -32,9 +32,7 @@ def generate(candidate_path, reference_path, method='identity'):
             system of the candidate/reference image with a weight for how
             a PIF the pixel is (0 for not a PIF)
     '''
-    logging.info('Pseudo invariant feature generation is using: Filtering ',
-                 'using the alpha mask.')
-    logging.info('Pseudo invariant feature generation is using: Filtering ',
+    logging.info('Pseudo invariant feature generation is using: Filtering '
                  'using the alpha mask.')
 
     reference_img = gimage.load(reference_path)
@@ -54,7 +52,7 @@ def _filter_zero_alpha_pifs(reference_gimage, candidate_gimage):
     value is zero (masked)
     '''
 
-    logging.info('Pseudo invariant feature generation is using: Filtering ',
+    logging.info('Pseudo invariant feature generation is using: Filtering '
                  'using the alpha mask.')
 
     gimage.check_comparable([reference_gimage, candidate_gimage])

--- a/radiometric_normalization/pif.py
+++ b/radiometric_normalization/pif.py
@@ -32,9 +32,6 @@ def generate(candidate_path, reference_path, method='identity'):
             system of the candidate/reference image with a weight for how
             a PIF the pixel is (0 for not a PIF)
     '''
-    logging.info('Pseudo invariant feature generation is using: Filtering '
-                 'using the alpha mask.')
-
     reference_img = gimage.load(reference_path)
     candidate_img = gimage.load(candidate_path)
 

--- a/radiometric_normalization/pif.py
+++ b/radiometric_normalization/pif.py
@@ -32,6 +32,11 @@ def generate(candidate_path, reference_path, method='identity'):
             system of the candidate/reference image with a weight for how
             a PIF the pixel is (0 for not a PIF)
     '''
+    logging.info('Pseudo invariant feature generation is using: Filtering ',
+                 'using the alpha mask.')
+    logging.info('Pseudo invariant feature generation is using: Filtering ',
+                 'using the alpha mask.')
+
     reference_img = gimage.load(reference_path)
     candidate_img = gimage.load(candidate_path)
 
@@ -48,6 +53,10 @@ def _filter_zero_alpha_pifs(reference_gimage, candidate_gimage):
     gimages by filtering out pixels where either the candidate or mask alpha
     value is zero (masked)
     '''
+
+    logging.info('Pseudo invariant feature generation is using: Filtering ',
+                 'using the alpha mask.')
+
     gimage.check_comparable([reference_gimage, candidate_gimage])
 
     all_mask = numpy.logical_not(numpy.logical_or(

--- a/radiometric_normalization/time_stack.py
+++ b/radiometric_normalization/time_stack.py
@@ -51,7 +51,7 @@ def generate(image_paths, output_path, method='identity', image_nodata=None):
                    for image_path in image_paths]
 
     if method == 'identity':
-        output_gimage = _mean_with_uniform_weight(
+        output_gimage = mean_with_uniform_weight(
             all_gimages, output_datatype)
     else:
         raise NotImplementedError("Only 'identity' method is implemented")

--- a/radiometric_normalization/time_stack.py
+++ b/radiometric_normalization/time_stack.py
@@ -58,6 +58,8 @@ def generate(image_paths, output_path, method='identity', image_nodata=None):
 
     gimage.save(output_gimage, output_path)
 
+    return output_path
+
 
 def _mean_one_band(all_gimages, band_index, output_datatype):
     ''' Calculates the reference as the mean of each band with uniform


### PR DESCRIPTION
Setting up normalize.py so that it can skip steps (e.g. time_stack.generate) for when we have pre-cached mosaics. 
