### PR TITLE
Cleaning up normalize

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,25 @@ The code in this repo is kept in two directories: 'radiometric_normalization' an
 'radiometric_normalization' contains the algorithm and functions of the library. 'normalize.py' is the top level module for the full workflow of running radiometric normalization and 'validate.py' is the module for validating radiometric normalization.
 
 'tests' contain unit tests for the functions in the library.
+
+
+## Example Usage
+
+The example below demonstrates the generation of per-band linear transformations that will normalize a candidate image to the mean values of a set of reference images. The candidate and reference images must be 16-bit. Additionally, all of the reference images in the set must have the same number and order bands and pixel dimensions as the candidate image.
+
+`candidate_path` is a string specifying the location of the candidate image on disk. `reference_paths` is a list of strings, each specifying the location of a reference image on disk. `transformations` is a list of tuples, each specifying the gain (first entry) and offset (second entry) that will normalize the respective band of the candidate image.
+
+```python
+
+reference_image = time_stack.generate(
+    reference_paths,
+    method='identity')
+
+pif_weight, reference_img, candidate_img = pif.generate(
+    candidate_path, reference_path=reference_image,
+    method='identity')
+
+transformations = transformation.generate(
+    pif_weight, reference_img, candidate_img,
+    method='linear_relationship')
+```

--- a/radiometric_normalization/gimage.py
+++ b/radiometric_normalization/gimage.py
@@ -161,7 +161,7 @@ def check_comparable(gimages, check_metadata=False):
     for i, image in enumerate(gimages[1:]):
         if len(image.bands) != no_bands:
             raise Exception(
-                'Image {} has a different number of bands: ' +
+                'Image {} has a different number of bands: '
                 '{} (initial: {})'.format(i + 1, len(image.bands), no_bands))
 
         if image.bands[0].shape != band_shape:
@@ -171,5 +171,5 @@ def check_comparable(gimages, check_metadata=False):
 
         if check_metadata and image.metadata != metadata:
             raise Exception(
-                'Image {} has different geographic metadata: {} ' +
+                'Image {} has different geographic metadata: {} '
                 '(initial: {})'.format(i + 1, image.metadata, metadata))

--- a/radiometric_normalization/normalize.py
+++ b/radiometric_normalization/normalize.py
@@ -17,7 +17,11 @@ from radiometric_normalization import \
     transformation, gimage
 
 
-def apply_transforms(input_path, transformations, output_path):
+def apply_transformations(input_path, transformations, output_path):
+    ''' This wrapper function applies the transformations
+    derived by the library onto two files.
+    '''
+
     gimg = gimage.load(input_path)
     out_gimg = transformation.apply(gimg, transformations)
     gimage.save(out_gimg, output_path)

--- a/radiometric_normalization/normalize.py
+++ b/radiometric_normalization/normalize.py
@@ -14,26 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 '''
 from radiometric_normalization import \
-    time_stack, pif, transformation, gimage
-
-
-def generate_transforms(candidate_path, reference_paths, config=None):
-    if config is None:
-        config = {'time_stack_method': 'identity',
-                  'pif_method': 'identity',
-                  'transformation_method': 'linear_relationship'}
-
-    reference_image = time_stack.generate(
-        reference_paths,
-        method=config['time_stack_method'])
-
-    pif_weight, reference_img, candidate_img = pif.generate(
-        candidate_path, reference_path=reference_image,
-        method=config['pif_method'])
-    transformations = transformation.generate(
-        pif_weight, reference_img, candidate_img,
-        method=config['transformation_method'])
-    return transformations
+    transformation, gimage
 
 
 def apply_transforms(input_path, transformations, output_path):

--- a/radiometric_normalization/pif.py
+++ b/radiometric_normalization/pif.py
@@ -32,6 +32,7 @@ def generate(candidate_path, reference_path, method='identity'):
             system of the candidate/reference image with a weight for how
             a PIF the pixel is (0 for not a PIF)
     '''
+
     reference_img = gimage.load(reference_path)
     candidate_img = gimage.load(candidate_path)
 
@@ -48,6 +49,10 @@ def _filter_zero_alpha_pifs(reference_gimage, candidate_gimage):
     gimages by filtering out pixels where either the candidate or mask alpha
     value is zero (masked)
     '''
+
+    logging.info('Pseudo invariant feature generation is using: Filtering '
+                 'using the alpha mask.')
+
     gimage.check_comparable([reference_gimage, candidate_gimage])
 
     all_mask = numpy.logical_not(numpy.logical_or(

--- a/radiometric_normalization/time_stack.py
+++ b/radiometric_normalization/time_stack.py
@@ -51,7 +51,7 @@ def generate(image_paths, output_path, method='identity', image_nodata=None):
                    for image_path in image_paths]
 
     if method == 'identity':
-        output_gimage = _mean_with_uniform_weight(
+        output_gimage = mean_with_uniform_weight(
             all_gimages, output_datatype)
     else:
         raise NotImplementedError("Only 'identity' method is implemented")


### PR DESCRIPTION
This replaces https://github.com/planetlabs/radiometric_normalization/pull/12

Instead of putting too much logic into this library to deal with every sort of situation that we might use the library for, we've decided to just directly call the library functions whenever it is used. Therefore less wrapper functions are required. 
