### PR TITLE
Changing the method names to something more understandable than identity

### DIFF
--- a/radiometric_normalization/pif.py
+++ b/radiometric_normalization/pif.py
@@ -19,7 +19,7 @@ import numpy
 from radiometric_normalization import gimage
 
 
-def generate(candidate_path, reference_path, method='identity'):
+def generate(candidate_path, reference_path, method='filter_nodata'):
     ''' Generates psuedo invariant features as a list of pixel pairs
 
     Input:
@@ -36,10 +36,10 @@ def generate(candidate_path, reference_path, method='identity'):
     reference_img = gimage.load(reference_path)
     candidate_img = gimage.load(candidate_path)
 
-    if method == 'identity':
+    if method == 'filter_nodata':
         pif_weight = _filter_zero_alpha_pifs(reference_img, candidate_img)
     else:
-        raise NotImplementedError("Only 'identity' method is implemented.")
+        raise NotImplementedError("Only 'filter_nodata' method is implemented.")
 
     return pif_weight, reference_img, candidate_img
 

--- a/radiometric_normalization/time_stack.py
+++ b/radiometric_normalization/time_stack.py
@@ -23,7 +23,7 @@ import logging
 from radiometric_normalization import gimage
 
 
-def generate(image_paths, output_path, method='identity', image_nodata=None):
+def generate(image_paths, output_path, method='mean_with_uniform_weight', image_nodata=None):
     '''Synthesizes a time stack image set into a single reference image.
 
     All images in time stack must:
@@ -50,11 +50,11 @@ def generate(image_paths, output_path, method='identity', image_nodata=None):
     all_gimages = [gimage.load(image_path, image_nodata)
                    for image_path in image_paths]
 
-    if method == 'identity':
+    if method == 'mean_with_uniform_weight':
         output_gimage = mean_with_uniform_weight(
             all_gimages, output_datatype)
     else:
-        raise NotImplementedError("Only 'identity' method is implemented")
+        raise NotImplementedError("Only 'mean_with_uniform_weight' method is implemented")
 
     gimage.save(output_gimage, output_path)
 

--- a/tests/time_stack_tests.py
+++ b/tests/time_stack_tests.py
@@ -20,7 +20,7 @@ from radiometric_normalization import time_stack, gimage
 
 
 class Tests(unittest.TestCase):
-    def test__mean_with_uniform_weight(self):
+    def test_mean_with_uniform_weight(self):
         # Three images of three bands of 2 by 2 pixels
         gimage_one = gimage.GImage(
             [numpy.array([[4, 1],
@@ -61,7 +61,7 @@ class Tests(unittest.TestCase):
             numpy.array([[65535, 0],
                          [65535, 65535]], dtype='uint16'), {})
 
-        output_gimage = time_stack._mean_with_uniform_weight(all_gimages,
+        output_gimage = time_stack.mean_with_uniform_weight(all_gimages,
                                                              numpy.uint16)
 
         for band in range(3):


### PR DESCRIPTION
time_stack.py: 'identity' to 'mean_with_uniform_weight'
pif.py: 'identity' to 'filter_nodata'
