### PR TITLE
Time stack memory improvements

### DIFF
--- a/radiometric_normalization/time_stack.py
+++ b/radiometric_normalization/time_stack.py
@@ -23,7 +23,8 @@ import logging
 from radiometric_normalization import gimage
 
 
-def generate(image_paths, output_path, method='mean_with_uniform_weight', image_nodata=None):
+def generate(image_paths, output_path,
+             method='mean_with_uniform_weight'):
     '''Synthesizes a time stack image set into a single reference image.
 
     All images in time stack must:
@@ -47,62 +48,87 @@ def generate(image_paths, output_path, method='mean_with_uniform_weight', image_
 
     output_datatype = numpy.uint16
 
-    all_gimages = [gimage.load(image_path, image_nodata)
-                   for image_path in image_paths]
-
     if method == 'mean_with_uniform_weight':
         output_gimage = mean_with_uniform_weight(
-            all_gimages, output_datatype)
+            image_paths, output_datatype)
     else:
-        raise NotImplementedError("Only 'mean_with_uniform_weight' method is implemented")
+        raise NotImplementedError("Only 'mean_with_uniform_weight'"
+                                  "method is implemented")
 
     gimage.save(output_gimage, output_path)
 
 
-def _mean_one_band(all_gimages, band_index, output_datatype):
-    ''' Calculates the reference as the mean of each band with uniform
-    weighting (zero for nodata pixels, 2 ** 16 - 1 for valid pixels)
+def _sum_masked_array_list(sum_masked_arrays,
+                           frequency_arrays,
+                           new_masked_arrays):
+    ''' Calculates the sum of two lists of masked arrays
 
     Input:
-        all_gimages (list of gimages): A list of all the gimage
-        band_index (int): Which band of the gimage to operate on
-        output_datatype (numpy datatype): Data type for the output image
-
+        sum_masked_arrays (list of masked arrays): A list of masked
+            arrays (one for each band)
+        frequency_arrays (list of arrays of ints): Keeping track of
+            how many times each pixel is summed (one for each band)
+        new_masked_arrays (list of masked arrays): A list of masked
+            arrays (one for each band)
     Output:
-        band_mean (numpy array): Output array representing the mean for
-            the specified
-        band_mask (numpy binary array): Mask representing the no data
-            values for this band (0 is a no data pixel, 1 is an active pixel)
+        sum_masked_array (masked array): A list of masked
+            arrays (one for each band)
     '''
+    no_bands = len(sum_masked_arrays)
+    for band_index in xrange(no_bands):
+        sum_masked_arrays[band_index] = \
+            numpy.ma.sum([sum_masked_arrays[band_index],
+                          new_masked_arrays[band_index]],
+                         axis=0)
+        frequency_arrays[band_index] = frequency_arrays[band_index] + \
+            numpy.logical_not(new_masked_arrays[band_index].mask).astype('int')
 
-    no_images = len(all_gimages)
-    one_band = \
-        [numpy.ma.masked_array(all_gimages[i].bands[band_index],
-                               all_gimages[i].alpha == 0)
-         for i in range(no_images)]
-
-    masked_mean = numpy.ma.mean(one_band, axis=0)
-    band_mean = masked_mean.data.astype(output_datatype)
-    band_mask = numpy.logical_not(masked_mean.mask)
-
-    return band_mean, band_mask
+    return sum_masked_arrays, frequency_arrays
 
 
-def _uniform_weight_alpha(all_masks, output_datatype):
-    '''Uses the gimages.mask entry to make a cumulative mask
-    of all the gimages in the list
+def _masked_arrays_from_gimg(input_gimg, working_datatype):
+    '''A gimage as input and outputs a masked array of output_datatype.
 
     Input:
-        all_gimages (list of gimages): The list of gimages to
-            find the cumulative mask of.
+        input_gimg (a gimage): A gimage to convert
+        working_datatype (numpy datatype): The datatype in use for
+            the calculations
 
     Output:
-        output_alpha (numpy uint16 array): The output mask.
+        all_bands (list of numpy arrays): A list of each band of the gimage
+            as a masked array
+    '''
+    no_bands = len(input_gimg.bands)
+    all_bands_masked_array_list = []
+    for band_index in xrange(no_bands):
+        one_band_masked_array = \
+            numpy.ma.masked_array(
+                input_gimg.bands[band_index].astype(working_datatype),
+                input_gimg.alpha == 0)
+        all_bands_masked_array_list.append(one_band_masked_array)
+
+    return all_bands_masked_array_list
+
+
+def _uniform_weight_alpha(sum_masked_arrays, output_datatype):
+    '''Calculates the cumulative mask of a list of masked array
+
+    Input:
+        sum_masked_arrays (list of numpy masked arrays): The list of
+            masked arrays to find the cumulative mask of, each element
+            represents one band.
+            (sums_masked_array.mask has a 1 for a no data pixel and
+            a 0 otherwise)
+        output_datatype (numpy datatype): The output datatype
+
+    Output:
+        output_alpha (numpy uint16 array): The output mask 
+            (0 for a no data pixel, uint16 max value otherwise)
     '''
 
-    output_alpha = numpy.ones(all_masks[0].shape)
-    for mask in all_masks:
-        output_alpha[numpy.nonzero(mask == 0)] = 0
+    output_alpha = numpy.ones(sum_masked_arrays[0].shape)
+    for band_sum_masked_array in sum_masked_arrays:
+        output_alpha[numpy.nonzero(band_sum_masked_array.mask == 1)] = 0
 
     output_alpha = output_alpha.astype(output_datatype) * \
         numpy.iinfo(output_datatype).max
@@ -110,15 +136,52 @@ def _uniform_weight_alpha(all_masks, output_datatype):
     return output_alpha
 
 
-def mean_with_uniform_weight(all_gimages, output_datatype):
-    ''' Calculates the reference as the mean of each band with uniform
+def _mean_from_sum(sum_masked_arrays,
+                   frequency_arrays,
+                   output_datatype):
+    ''' Calculates the mean from the summation of all the images
+
+    Input: 
+        sum_masked_arrays (list of numpy masked arrays): The list of
+            masked arrays to find the mean of, each element of the list
+            represents one band.
+            (sums_masked_array.mask has a 1 for a no data pixel and
+            a 0 otherwise)
+        frequency_arrays (numpy array of ints): The number of times each
+            pixel has been summed
+        output_datatype (numpy data type): The output datatype
+
+    Output:
+        output_mean(list of numpy arrays): A list of the means of the
+            images. Each element of the list represents one band.
+    '''
+    no_bands = len(sum_masked_arrays)
+    output_mean = []
+    for band_index in xrange(no_bands):
+        output_band = numpy.zeros(frequency_arrays[band_index].shape)
+        good_indices = numpy.nonzero(frequency_arrays[band_index] != 0)
+        output_band[good_indices] = \
+            sum_masked_arrays[band_index].data[good_indices] / \
+            frequency_arrays[band_index][good_indices]
+        output_mean.append(output_band.astype(output_datatype))
+
+    return output_mean
+
+
+def mean_with_uniform_weight(image_paths, output_datatype):
+    ''' Calculates the reference image as the mean of each band with uniform
     weighting (zero for nodata pixels, 2 ** 16 - 1 for valid pixels)
 
+    The input are a set of uint16 geotiffs, the output is a uint16 geotiff but
+    inbetween we use numpy double masked arrays so that we can safely take the
+    summation of all the values without reaching the maximum value.
+
+    This function is written so that it should only load two gimages into 
+    memory at any one time (to save memory when analysing lists of > 100 
+    images)
+
     Input:
-        all_bands (list of list of arrays): A list of each band,
-            each band consisting of a list of images each entry being a
-            masked array of the image data
-        output_nodata (number): The no data value for the output image
+        image_paths (list of strings): A list of image paths for each image
         output_datatype (numpy datatype): Data type for the output image
 
     Output:
@@ -127,20 +190,32 @@ def mean_with_uniform_weight(all_gimages, output_datatype):
     '''
 
     logging.info('Time stack analysis is using: Mean with uniform weight.')
-    gimage.check_comparable(all_gimages, check_metadata=True)
 
-    no_bands = len(all_gimages[0].bands)
-    all_means = []
-    all_masks = []
-    for band in range(no_bands):
-        band_mean, band_mask = _mean_one_band(
-            all_gimages, band, output_datatype)
-        all_means.append(band_mean)
-        all_masks.append(band_mask)
+    working_datatype = numpy.double
+    no_images = len(image_paths)
+    first_gimg = gimage.load(image_paths[0])
 
-    output_alpha = _uniform_weight_alpha(all_masks, output_datatype)
+    sum_masked_arrays = _masked_arrays_from_gimg(first_gimg,
+                                                 working_datatype)
 
-    output_gimage = gimage.GImage(all_means, output_alpha,
-                                  all_gimages[0].metadata)
+    no_bands = len(sum_masked_arrays)
+    frequency_arrays = \
+        [numpy.logical_not(sum_masked_arrays[band_index].mask).astype('int')
+         for band_index in xrange(no_bands)]
+
+    for image_index in xrange(1, no_images):
+        new_gimg = gimage.load(image_paths[image_index])
+        gimage.check_comparable([first_gimg, new_gimg], check_metadata=True)
+
+        new_masked_arrays = _masked_arrays_from_gimg(new_gimg, working_datatype)
+        sum_masked_arrays, frequency_arrays = _sum_masked_array_list(
+            sum_masked_arrays, frequency_arrays, new_masked_arrays)
+
+    output_alpha = _uniform_weight_alpha(sum_masked_arrays, output_datatype)
+    output_bands = _mean_from_sum(sum_masked_arrays, frequency_arrays,
+                                   output_datatype)
+
+    output_gimage = gimage.GImage(output_bands, output_alpha,
+                                  first_gimg.metadata)
 
     return output_gimage

--- a/radiometric_normalization/time_stack.py
+++ b/radiometric_normalization/time_stack.py
@@ -24,7 +24,8 @@ from radiometric_normalization import gimage
 
 
 def generate(image_paths, output_path,
-             method='mean_with_uniform_weight'):
+             method='mean_with_uniform_weight',
+             image_nodata=None):
     '''Synthesizes a time stack image set into a single reference image.
 
     All images in time stack must:
@@ -50,7 +51,7 @@ def generate(image_paths, output_path,
 
     if method == 'mean_with_uniform_weight':
         output_gimage = mean_with_uniform_weight(
-            image_paths, output_datatype)
+            image_paths, output_datatype, image_nodata)
     else:
         raise NotImplementedError("Only 'mean_with_uniform_weight'"
                                   "method is implemented")
@@ -168,7 +169,7 @@ def _mean_from_sum(sum_masked_arrays,
     return output_mean
 
 
-def mean_with_uniform_weight(image_paths, output_datatype):
+def mean_with_uniform_weight(image_paths, output_datatype, image_nodata):
     ''' Calculates the reference image as the mean of each band with uniform
     weighting (zero for nodata pixels, 2 ** 16 - 1 for valid pixels)
 
@@ -193,7 +194,7 @@ def mean_with_uniform_weight(image_paths, output_datatype):
 
     working_datatype = numpy.double
     no_images = len(image_paths)
-    first_gimg = gimage.load(image_paths[0])
+    first_gimg = gimage.load(image_paths[0], image_nodata)
 
     sum_masked_arrays = _masked_arrays_from_gimg(first_gimg,
                                                  working_datatype)

--- a/tests/time_stack_tests.py
+++ b/tests/time_stack_tests.py
@@ -67,7 +67,8 @@ class Tests(unittest.TestCase):
             {'geotransform': (0.0, 1.0, 0.0, 0.0, 0.0, 1.0)})
 
         output_gimage = time_stack.mean_with_uniform_weight(image_paths,
-                                                            numpy.uint16)
+                                                            numpy.uint16,
+                                                            None)
 
         for band in range(3):
             numpy.testing.assert_array_equal(output_gimage.bands[band],


### PR DESCRIPTION
This implementation of time stack now only loads two gimages ever at one time. This should mean it can be used with time stacks of hundreds of images. 
