### PR TITLE
Adding a compression option to gimage plus updating the unit test

### DIFF
--- a/radiometric_normalization/gimage.py
+++ b/radiometric_normalization/gimage.py
@@ -27,18 +27,22 @@ from osgeo import gdal, gdal_array
 GImage = namedtuple('GImage', 'bands, alpha, metadata')
 
 
-def save(gimage, filename, nodata=None):
-    gdal_ds = create_ds(gimage, filename)
+def save(gimage, filename, nodata=None, compress=False):
+    gdal_ds = create_ds(gimage, filename, compress)
     save_to_ds(gimage, gdal_ds, nodata)
 
 
-def create_ds(gimage, filename):
+def create_ds(gimage, filename, compress):
     # Alpha is saved as the last band
     band_count = len(gimage.bands) + 1
     options = ['ALPHA=YES']
 
     if band_count == 4:
         options.append('PHOTOMETRIC=RGB')
+
+    if compress:
+        options.append('COMPRESS=DEFLATE')
+        options.append('PREDICTOR=2')
 
     datatype = gdal.GDT_UInt16
     ysize, xsize = gimage.bands[0].shape

--- a/radiometric_normalization/gimage.py
+++ b/radiometric_normalization/gimage.py
@@ -27,7 +27,7 @@ from osgeo import gdal, gdal_array
 GImage = namedtuple('GImage', 'bands, alpha, metadata')
 
 
-def save(gimage, filename, nodata=None, compress=False):
+def save(gimage, filename, nodata=None, compress=True):
     gdal_ds = create_ds(gimage, filename, compress)
     save_to_ds(gimage, gdal_ds, nodata)
 

--- a/radiometric_normalization/time_stack.py
+++ b/radiometric_normalization/time_stack.py
@@ -52,7 +52,7 @@ def generate(image_paths, output_path,
         raise NotImplementedError("Only 'mean_with_uniform_weight'"
                                   "method is implemented")
 
-    gimage.save(output_gimage, output_path)
+    gimage.save(output_gimage, output_path, compress=False)
 
 
 def _sum_masked_array_list(sum_masked_arrays,

--- a/tests/gimage_tests.py
+++ b/tests/gimage_tests.py
@@ -72,7 +72,8 @@ class Tests(unittest.TestCase):
         test_band = numpy.array([[0, 1, 2], [2, 3, 4]], dtype=numpy.uint16)
         test_gimage = gimage.GImage([test_band], self.mask, self.metadata)
         test_compress = False
-        test_ds = gimage.create_ds(test_gimage, output_file, test_compress)
+        test_ds = gimage.create_ds(test_gimage, output_file,
+                                   compress=test_compress)
 
         self.assertEqual(test_ds.RasterCount, 2)
         self.assertEqual(test_ds.RasterXSize, 3)

--- a/tests/gimage_tests.py
+++ b/tests/gimage_tests.py
@@ -71,11 +71,30 @@ class Tests(unittest.TestCase):
         output_file = 'test_create_ds.tif'
         test_band = numpy.array([[0, 1, 2], [2, 3, 4]], dtype=numpy.uint16)
         test_gimage = gimage.GImage([test_band], self.mask, self.metadata)
-        test_ds = gimage.create_ds(test_gimage, output_file)
+        test_compress = False
+        test_ds = gimage.create_ds(test_gimage, output_file, test_compress)
 
         self.assertEqual(test_ds.RasterCount, 2)
         self.assertEqual(test_ds.RasterXSize, 3)
         self.assertEqual(test_ds.RasterYSize, 2)
+
+        os.unlink(output_file)
+
+    def test_save_with_compress(self):
+        output_file = 'test_save_with_compress.tif'
+        test_band = numpy.array([[5, 2, 2], [1, 6, 8]], dtype=numpy.uint16)
+        test_alpha = numpy.array([[0, 0, 0], [65535, 65535, 65535]],
+                                 dtype=numpy.uint16)
+        test_gimage = gimage.GImage([test_band, test_band, test_band],
+                                    test_alpha, self.metadata)
+        gimage.save(test_gimage, output_file, compress=True)
+
+        result_gimg = gimage.load(output_file)
+        numpy.testing.assert_array_equal(result_gimg.bands[0], test_band)
+        numpy.testing.assert_array_equal(result_gimg.bands[1], test_band)
+        numpy.testing.assert_array_equal(result_gimg.bands[2], test_band)
+        numpy.testing.assert_array_equal(result_gimg.alpha, test_alpha)
+        self.assertEqual(result_gimg.metadata, self.metadata)
 
         os.unlink(output_file)
 


### PR DESCRIPTION
I found this hugely useful (especially with lots of images). 

I'm kind of tempted to make it default but it does make the save operation slower.

A sample scene:
- Without compression = 4.990463s, 109MB
- With compression = 9.021566s, 48MB
